### PR TITLE
download-image: Handle both qcow2 and qcow2.xz files

### DIFF
--- a/download-image.sh
+++ b/download-image.sh
@@ -3,7 +3,15 @@
 set -e
 
 base_url="https://download.opensuse.org/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/"
-name=$(curl --silent "$base_url" | pandoc -f html -t plain | egrep -e 'kubeadm-cri-o-kvm-and-xen.*qcow2.xz$')
+name_xz=$(curl --silent "$base_url" | pandoc -f html -t plain | egrep -e 'kubeadm-cri-o-kvm-and-xen.*qcow2.xz$' || true)
+name=$(curl --silent "$base_url" | pandoc -f html -t plain | egrep -e 'kubeadm-cri-o-kvm-and-xen.*qcow2$' || true)
 
-wget -O kubic.qcow2.xz "$base_url$name"
-xz -f -v --decompress kubic.qcow2.xz
+if [[ ! -z "$name_xz" ]]; then
+    wget -O kubic.qcow2.xz "$base_url$name_xz"
+    xz -f -v --decompress kubic.qcow2.xz
+elif [[ ! -z "$name" ]]; then
+    wget -O kubic.qcow2 "$base_url$name"
+else
+    echo "Error: Could not find kubeadm-cri-o-kvm-and-xen image on $base_url"
+    exit 1
+fi


### PR DESCRIPTION
Before this change, the script assumed that kubeadm-cri* image is
always distributed in form of .xz archive, which is not always true.
Sometimes only unarchived .qcow2 image is available.

Fixes: 59b52671d4a6 ("Fix terraform, add download-image.sh")

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>