### PR TITLE
download-image: Perform sha256 sum check when file exists

### DIFF
--- a/download-image.py
+++ b/download-image.py
@@ -42,7 +42,7 @@ def download_image(url: str, dst):
 if __name__ == '__main__':
     dst = 'kubic.qcow2'
     url = base_url + image_name
-    if local_sha256(dst) == remote_sha256(url):
+    if os.path.isfile(dst) and local_sha256(dst) == remote_sha256(url):
         print('already downloaded.')
     else:
         download_image(url, dst)


### PR DESCRIPTION
Before this change, download-image.py script was trying to open
kubic.qcow2 file for sha256 sum check regardless of whether the file
existed.

Fixes: #9
Fixes: f46bfaa5c87c ("download-image.sh: Load only new images")

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>